### PR TITLE
Bug Fix for Polygons with incorrect holes

### DIFF
--- a/Assets/Plugins/x64/Gdal.meta
+++ b/Assets/Plugins/x64/Gdal.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: e3c046cc381d38d4a86540f95dbcdfc7
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Basic Types/typings.cs
+++ b/Assets/Scripts/Basic Types/typings.cs
@@ -57,7 +57,7 @@ namespace Virgis
         }
     }
 
-    public static class Vector3ExtebnsionMethods {
+    public static class Vector3ExtensionMethods {
         /// <summary>
         /// Convert Vector3 World Space location to Position taking account of zoom, scale and mapscale
         /// </summary>
@@ -251,19 +251,22 @@ namespace Virgis
                     vertices[j] = VertexTable.Find(item => item.Vertex == j).Com.transform.position;
                 }
                 List<Vector2d> vertices2d = new List<Vector2d>();
-                foreach (Vector3d v in vertices)
-                    vertices2d.Add(frame.ToPlaneUV((Vector3f) v, 3));
+                foreach (Vector3d v in vertices) {
+                    Vector2f vertex = frame.ToPlaneUV((Vector3f) v, 3);
+                    if (i != 0 && !poly.Outer.Contains(vertex))
+                        break;
+                    vertices2d.Add(vertex);
+                }
                 Polygon2d p2d = new Polygon2d(vertices2d);
                 if (i == 0) {
                     p2d = new Polygon2d(vertices2d);
                     p2d.Reverse();
                     poly.Outer = p2d;
                 } else {
-                    
                     try {
-                        
                         poly.AddHole(p2d, true, true);
                     } catch {
+                        p2d.Reverse();
                         poly.AddHole(p2d, true, true);
                     }
                    

--- a/Assets/StreamingAssets/Examples.meta
+++ b/Assets/StreamingAssets/Examples.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 660c1f1fdfc56a54face5a74e6c35637
+guid: 574be5ff629a89f43b66e49b163e9128
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
Avoids a fatal error if the hole is not correctly positioned in the polygon, as can happen if the face angles are too high.